### PR TITLE
Add ImageUrl property to Plane model

### DIFF
--- a/WrightBrothersApi/WrightBrothersApi/Models/Plane.cs
+++ b/WrightBrothersApi/WrightBrothersApi/Models/Plane.cs
@@ -11,5 +11,7 @@ namespace WrightBrothersApi.Models
         public string Description { get; set; }
 
         public int RangeInKm { get; set; }
+
+        public string ImageUrl { get; set; }
     }
 }


### PR DESCRIPTION
This pull request includes a small change to the `Plane` class in the `WrightBrothersApi/Models/Plane.cs` file. The change adds a new property `ImageUrl` to the class, which presumably will be used to store the URL of an image representing the plane.